### PR TITLE
Add wakeup call for sleeping servers

### DIFF
--- a/voice-chess-react/src/components/socketVoice.tsx
+++ b/voice-chess-react/src/components/socketVoice.tsx
@@ -340,6 +340,19 @@ const SocketVoice = (props: ISocketVoiceProps) => {
     let serverPoolInx = -1; // will increment first - TODO - make random
     //let serverPoolInx = Math.floor(serverPool.length * Math.random()) - 1;
 
+    // WAKE UP SERVERS
+    // Dummy read from server url in case it is sleeping (added for herokuapp.com)
+    /**/
+    serverPool.forEach(url => {
+      console.log(url);
+      fetch(url, {mode: 'no-cors'})
+        .then(response => {
+          console.log('Pinged: ' + url)
+        })
+      // no return processed from promise, we just wanted to ping them
+    });
+    /**/
+
     //
     // Function: serverConnect
     //


### PR DESCRIPTION
Makes dummy calls to servers in the pool to wake-up, required by herokuapp as it takes some time for them to wake up when we try to connect.